### PR TITLE
feat: rename snapshot check to diff, add auto-sort, add list

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,4 +9,5 @@ for git_var in $(git rev-parse --local-env-vars); do
 done
 
 printf '%s\n' "Running AGT pre-commit safety checks..."
+"$repo_root/.githooks/validate-version.sh"
 make check

--- a/.githooks/validate-version.sh
+++ b/.githooks/validate-version.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+git_bin=${AGT_GIT_PATH:-$(command -v git)}
+repo_root=$($git_bin rev-parse --show-toplevel)
+cd "$repo_root"
+
+latest_tag=$($git_bin describe --tags --match "release/*" --abbrev=0 2>/dev/null || true)
+
+if [ -z "$latest_tag" ]; then
+	exit 0
+fi
+
+case "$latest_tag" in
+release/*)
+	latest_version=${latest_tag#release/}
+	;;
+*)
+	exit 0
+	;;
+esac
+
+latest_base=${latest_version%%-*}
+
+read_version() {
+	awk -F '"' '/^version = "/ { print $2; exit }' "$1"
+}
+
+check_version_file() {
+	file=$1
+	current_version=$(read_version "$file")
+	if [ -z "$current_version" ]; then
+		printf '%s\n' "ERROR: could not read version from $file" >&2
+		exit 1
+	fi
+
+	if [ "$current_version" != "$latest_base" ]; then
+		printf '%s\n' "ERROR: $file version $current_version does not match latest reachable release base $latest_base ($latest_tag)" >&2
+		exit 1
+	fi
+}
+
+check_version_file "Cargo.toml"
+check_version_file "crates/agt/Cargo.toml"
+check_version_file "crates/agt-worktree/Cargo.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       release_kind: ${{ steps.meta.outputs.release_kind }}
       release_tag: ${{ steps.meta.outputs.release_tag }}
       release_title: ${{ steps.meta.outputs.release_title }}
+      build_date: ${{ steps.meta.outputs.build_date }}
       binary_suffix: ${{ steps.meta.outputs.binary_suffix }}
       asset_suffix: ${{ steps.meta.outputs.asset_suffix }}
       release_notes: ${{ steps.meta.outputs.release_notes }}
@@ -44,12 +45,14 @@ jobs:
           release_kind=none
           release_tag=
           release_title=
+          build_date=
           binary_suffix=
           asset_suffix=
           release_notes=
 
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
             short_sha="${GITHUB_SHA::12}"
+            build_date="$(date -u +%Y.%m.%d)"
             publish=true
             release_kind=nightly
             release_tag=nightly
@@ -59,13 +62,13 @@ jobs:
             release_notes="Draft nightly release from main at ${GITHUB_SHA}."
           elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/release/* ]]; then
             version="${GITHUB_REF_NAME#release/}"
-            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?$ ]]; then
               echo "ERROR: Tag version '$version' is not semver compliant. Use format: release/X.Y.Z or release/X.Y.Z-suffix"
               exit 1
             fi
             publish=true
             release_kind=semver
-            release_tag="${GITHUB_REF_NAME}"
+            release_tag="${version}"
             release_title="${version}"
             binary_suffix="${version}"
             asset_suffix="${version}"
@@ -77,6 +80,7 @@ jobs:
             echo "release_kind=${release_kind}"
             echo "release_tag=${release_tag}"
             echo "release_title=${release_title}"
+            echo "build_date=${build_date}"
             echo "binary_suffix=${binary_suffix}"
             echo "asset_suffix=${asset_suffix}"
             echo "release_notes=${release_notes}"
@@ -86,6 +90,9 @@ jobs:
     name: ${{ matrix.name }}
     needs: release-meta
     runs-on: ${{ matrix.runner }}
+    env:
+      AGT_BUILD_CHANNEL: ${{ needs.release-meta.outputs.release_kind == 'nightly' && 'nightly' || '' }}
+      AGT_BUILD_DATE: ${{ needs.release-meta.outputs.build_date }}
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +107,8 @@ jobs:
             archive_name: agt-windows
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Resolve Git on Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -191,10 +200,15 @@ jobs:
     name: Debian Trixie
     needs: release-meta
     runs-on: ubuntu-latest
+    env:
+      AGT_BUILD_CHANNEL: ${{ needs.release-meta.outputs.release_kind == 'nightly' && 'nightly' || '' }}
+      AGT_BUILD_DATE: ${{ needs.release-meta.outputs.build_date }}
     container:
       image: debian:trixie
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install system dependencies
         run: |
           apt-get update

--- a/DESIGN_20260104.md
+++ b/DESIGN_20260104.md
@@ -53,7 +53,7 @@ If an agent supports a "fork" so that you can have two sessions with divergent h
 | `agt session restore` | Checkout the `sessions/<id>/` to a prior shadow state |
 | `agt session fork <from-id>` | Fork existing session (advanced, for parallel work)  |
 | `agt snapshot save` | Save a standalone snapshot of an arbitrary tree into an isolated snapshot store |
-| `agt snapshot check` | Compare two standalone snapshots |
+| `agt snapshot diff <snapshot-a> <snapshot-b>` | Compare two standalone snapshots |
 | `agt snapshot status` | Compare the current tree against the latest standalone snapshot |
 | `agt snapshot restore` | Restore all or part of a standalone snapshot |
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ A dual-mode Git wrapper that spawns the host git binary and filters its output:
 - **As `agt`**: Full visibility plus session management commands
 
 Key commands:
+- `agt setup` - Create standalone snapshot storage and gitignore it when appropriate
 - `agt clone <url>` - Clone remote repo into agt-managed structure
 - `agt session new [--id <id>]` - Create new agent session
 - `agt session export` - Push user branch to remote origin
 - `agt session remove --id <id>` - Remove a session
 - `agt autocommit --session-id <id>` - Capture session shadow history
 - `agt snapshot save` - Save a standalone filesystem snapshot into an isolated store
-- `agt snapshot check` - Compare two standalone snapshots
+- `agt snapshot diff <snapshot-a> <snapshot-b>` - Compare two standalone snapshots
 - `agt snapshot status` - Compare the current tree against the latest standalone snapshot
 - `agt snapshot restore` - Restore all or part of a saved standalone snapshot
 
@@ -73,6 +74,8 @@ AGT now uses the word "snapshot" in two different namespaces:
 - **Standalone snapshots** come from `agt snapshot ...` and live in a separate snapshot store, defaulting to `.agt-snapshots/` in the current working directory.
 
 Standalone snapshots are designed for answering "what changed?" across generated output and ignored files without interfering with normal Git history or AGT session flows.
+
+Use `agt setup` to bootstrap the standalone snapshot store before the first snapshot. By default it creates `.agt-snapshots/` in the current directory and, when running inside a Git repository, ensures the repository root `.gitignore` ignores that store. `agt setup --store <path>` bootstraps a custom store path instead.
 
 ## Configuration
 
@@ -129,6 +132,9 @@ agt autocommit -C sessions/agent-001 --session-id agent-001
 # Export user branch to remote
 agt session export --session-id agent-001
 
+# Bootstrap standalone snapshot storage
+agt setup
+
 # Save a standalone snapshot before running an agent
 agt snapshot save -m "before run"
 
@@ -168,6 +174,15 @@ make build            # Build all binaries to dist/
 After building, binaries are in `dist/`:
 - `dist/agt` - Host-side AGT CLI
 - `dist/agt-worktree` - Sandbox helper used inside agent sessions
+
+### Build Versioning
+
+AGT follows a strict Git-tag-driven semantic versioning policy.
+
+- For the full `--version` contract and build-version rules, see
+  [docs/agt.1.txt](docs/agt.1.txt).
+- For the release and nightly publishing workflow, see
+  [.github/workflows/ci.yml](.github/workflows/ci.yml).
 
 Run AGT from the `dist/` folder or add it to your PATH:
 

--- a/build/build_version_support.rs
+++ b/build/build_version_support.rs
@@ -1,0 +1,98 @@
+pub fn parse_release_ref(ref_name: &str) -> Option<&str> {
+    let version = ref_name.strip_prefix("release/")?;
+    if is_valid_release_version(version) {
+        Some(version)
+    } else {
+        None
+    }
+}
+
+pub fn is_valid_release_version(version: &str) -> bool {
+    let (base, suffix) = match version.split_once('-') {
+        Some((base, suffix)) => (base, Some(suffix)),
+        None => (version, None),
+    };
+
+    if !is_valid_semver_triplet(base) {
+        return false;
+    }
+
+    suffix.is_none_or(is_valid_suffix)
+}
+
+pub fn format_local_version(base: &str, sha: &str, dirty: bool) -> String {
+    let mut version = format!("{base}-{sha}");
+    if dirty {
+        version.push_str("+dirty");
+    }
+    version
+}
+
+pub fn format_nightly_version(build_date: &str, sha: &str) -> String {
+    format!("{build_date}-{sha}")
+}
+
+fn is_valid_semver_triplet(value: &str) -> bool {
+    let mut parts = value.split('.');
+    let a = parts.next();
+    let b = parts.next();
+    let c = parts.next();
+
+    parts.next().is_none()
+        && a.is_some_and(is_numeric)
+        && b.is_some_and(is_numeric)
+        && c.is_some_and(is_numeric)
+}
+
+fn is_numeric(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn is_valid_suffix(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        format_local_version, format_nightly_version, is_valid_release_version, parse_release_ref,
+    };
+
+    #[test]
+    fn parses_release_refs() {
+        assert_eq!(parse_release_ref("release/0.1.0"), Some("0.1.0"));
+        assert_eq!(parse_release_ref("release/0.1.0-rc1"), Some("0.1.0-rc1"));
+        assert_eq!(parse_release_ref("0.1.0"), None);
+        assert_eq!(parse_release_ref("release/v0.1.0"), None);
+    }
+
+    #[test]
+    fn validates_release_versions() {
+        assert!(is_valid_release_version("0.1.0"));
+        assert!(is_valid_release_version("12.34.56-rc1"));
+        assert!(is_valid_release_version("12.34.56-rc.1"));
+        assert!(!is_valid_release_version("v0.1.0"));
+        assert!(!is_valid_release_version("0.1"));
+        assert!(!is_valid_release_version("0.1.0-"));
+        assert!(!is_valid_release_version("0.1.0+build"));
+    }
+
+    #[test]
+    fn formats_versions() {
+        assert_eq!(
+            format_nightly_version("2026.03.22", "abcdef123456"),
+            "2026.03.22-abcdef123456"
+        );
+        assert_eq!(
+            format_local_version("0.1.0", "abcdef123456", false),
+            "0.1.0-abcdef123456"
+        );
+        assert_eq!(
+            format_local_version("0.1.0", "abcdef123456", true),
+            "0.1.0-abcdef123456+dirty"
+        );
+    }
+}

--- a/crates/agt-worktree/build.rs
+++ b/crates/agt-worktree/build.rs
@@ -1,0 +1,102 @@
+#[path = "../../build/build_version_support.rs"]
+mod build_version_support;
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=AGT_BUILD_CHANNEL");
+    println!("cargo:rerun-if-env-changed=AGT_BUILD_DATE");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../build/build_version_support.rs");
+
+    emit_git_rerun_hints();
+
+    let base_version = env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION should be set");
+    let short_sha = git(&["rev-parse", "--short=12", "HEAD"]);
+    let dirty = git(&["status", "--porcelain"])
+        .map(|status| !status.is_empty())
+        .unwrap_or(false);
+
+    let version = match env::var("AGT_BUILD_CHANNEL").ok().as_deref() {
+        Some("nightly") => {
+            let build_date = env::var("AGT_BUILD_DATE")
+                .expect("AGT_BUILD_DATE must be set when AGT_BUILD_CHANNEL=nightly");
+            let sha = short_sha.clone().unwrap_or_else(|| String::from("unknown"));
+            build_version_support::format_nightly_version(&build_date, &sha)
+        }
+        Some(other) => panic!("unsupported AGT_BUILD_CHANNEL: {other}"),
+        None => {
+            if !dirty {
+                if let Some(version) = exact_release_version() {
+                    version
+                } else if let Some(sha) = short_sha.as_deref() {
+                    build_version_support::format_local_version(&base_version, sha, dirty)
+                } else {
+                    base_version
+                }
+            } else if let Some(sha) = short_sha.as_deref() {
+                build_version_support::format_local_version(&base_version, sha, dirty)
+            } else {
+                format!("{base_version}+dirty")
+            }
+        }
+    };
+
+    println!("cargo:rustc-env=AGT_BUILD_VERSION={version}");
+}
+
+fn exact_release_version() -> Option<String> {
+    let tag = git(&[
+        "describe",
+        "--tags",
+        "--exact-match",
+        "--match",
+        "release/*",
+    ])?;
+    build_version_support::parse_release_ref(&tag).map(ToOwned::to_owned)
+}
+
+fn emit_git_rerun_hints() {
+    let Some(git_dir) = git(&["rev-parse", "--git-dir"]) else {
+        return;
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let git_dir = absolutize(&manifest_dir, Path::new(&git_dir));
+
+    for path in [
+        git_dir.join("HEAD"),
+        git_dir.join("index"),
+        git_dir.join("packed-refs"),
+        git_dir.join("refs/heads"),
+        git_dir.join("refs/tags"),
+    ] {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn absolutize(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}

--- a/crates/agt-worktree/src/main.rs
+++ b/crates/agt-worktree/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::AtomicBool;
 #[derive(Parser)]
 #[command(name = "agt-worktree")]
 #[command(about = "Minimal worktree add/remove helper for agt")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = env!("AGT_BUILD_VERSION"))]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/crates/agt/build.rs
+++ b/crates/agt/build.rs
@@ -1,0 +1,102 @@
+#[path = "../../build/build_version_support.rs"]
+mod build_version_support;
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=AGT_BUILD_CHANNEL");
+    println!("cargo:rerun-if-env-changed=AGT_BUILD_DATE");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../../build/build_version_support.rs");
+
+    emit_git_rerun_hints();
+
+    let base_version = env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION should be set");
+    let short_sha = git(&["rev-parse", "--short=12", "HEAD"]);
+    let dirty = git(&["status", "--porcelain"])
+        .map(|status| !status.is_empty())
+        .unwrap_or(false);
+
+    let version = match env::var("AGT_BUILD_CHANNEL").ok().as_deref() {
+        Some("nightly") => {
+            let build_date = env::var("AGT_BUILD_DATE")
+                .expect("AGT_BUILD_DATE must be set when AGT_BUILD_CHANNEL=nightly");
+            let sha = short_sha.clone().unwrap_or_else(|| String::from("unknown"));
+            build_version_support::format_nightly_version(&build_date, &sha)
+        }
+        Some(other) => panic!("unsupported AGT_BUILD_CHANNEL: {other}"),
+        None => {
+            if !dirty {
+                if let Some(version) = exact_release_version() {
+                    version
+                } else if let Some(sha) = short_sha.as_deref() {
+                    build_version_support::format_local_version(&base_version, sha, dirty)
+                } else {
+                    base_version
+                }
+            } else if let Some(sha) = short_sha.as_deref() {
+                build_version_support::format_local_version(&base_version, sha, dirty)
+            } else {
+                format!("{base_version}+dirty")
+            }
+        }
+    };
+
+    println!("cargo:rustc-env=AGT_BUILD_VERSION={version}");
+}
+
+fn exact_release_version() -> Option<String> {
+    let tag = git(&[
+        "describe",
+        "--tags",
+        "--exact-match",
+        "--match",
+        "release/*",
+    ])?;
+    build_version_support::parse_release_ref(&tag).map(ToOwned::to_owned)
+}
+
+fn emit_git_rerun_hints() {
+    let Some(git_dir) = git(&["rev-parse", "--git-dir"]) else {
+        return;
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let git_dir = absolutize(&manifest_dir, Path::new(&git_dir));
+
+    for path in [
+        git_dir.join("HEAD"),
+        git_dir.join("index"),
+        git_dir.join("packed-refs"),
+        git_dir.join("refs/heads"),
+        git_dir.join("refs/tags"),
+    ] {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn absolutize(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}

--- a/crates/agt/src/cli.rs
+++ b/crates/agt/src/cli.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 #[derive(Parser)]
 #[command(name = "agt")]
 #[command(about = "Agent Git Tool - AI agent session management with immutable snapshots")]
-#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(version = env!("AGT_BUILD_VERSION"))]
 pub struct Cli {
     /// Disable agt filtering (git mode only)
     #[arg(long, global = true)]
@@ -25,6 +25,13 @@ pub struct Cli {
 
 #[derive(Subcommand, Clone)]
 pub enum Commands {
+    /// Bootstrap standalone snapshot storage for the current directory
+    Setup {
+        /// Snapshot store directory to create
+        #[arg(long)]
+        store: Option<PathBuf>,
+    },
+
     /// Clone a remote repository into agt-managed structure
     Clone {
         /// Remote repository URL
@@ -77,13 +84,13 @@ pub enum SnapshotCommands {
         message: Option<String>,
     },
 
-    /// Compare two saved snapshots
-    Check {
-        /// Earlier snapshot tag name
-        #[arg(long)]
+    /// Compare two saved snapshots and report deleted, modified, and added paths
+    Diff {
+        /// Earlier snapshot tag (or newer if you want additions reported as deletions)
+        #[arg(value_name = "snapshot-a")]
         before: String,
-        /// Later snapshot tag name
-        #[arg(long)]
+        /// Later snapshot tag (or older if you want deletions reported as additions)
+        #[arg(value_name = "snapshot-b")]
         after: String,
         /// Override snapshot store location
         #[arg(long)]
@@ -98,6 +105,13 @@ pub enum SnapshotCommands {
         /// Reduce output; repeat for no output and exit status only
         #[arg(short = 'q', action = ArgAction::Count)]
         quiet: u8,
+    },
+
+    /// List saved standalone snapshots
+    List {
+        /// Override snapshot store location
+        #[arg(long)]
+        store: Option<PathBuf>,
     },
 
     /// Restore files from a saved snapshot

--- a/crates/agt/src/commands/snapshot.rs
+++ b/crates/agt/src/commands/snapshot.rs
@@ -11,7 +11,7 @@ pub fn run(repo: &Repository, command: SnapshotCommands, config: &AgtConfig) -> 
             store,
             message,
         } => snapshot::save(repo, config, &target, store.as_deref(), message.as_deref()),
-        SnapshotCommands::Check {
+        SnapshotCommands::Diff {
             before,
             after,
             store,
@@ -19,6 +19,7 @@ pub fn run(repo: &Repository, command: SnapshotCommands, config: &AgtConfig) -> 
         SnapshotCommands::Status { store, quiet } => {
             snapshot::status(repo, store.as_deref(), quiet)
         }
+        SnapshotCommands::List { store } => snapshot::list(repo, store.as_deref()),
         SnapshotCommands::Restore {
             snapshot: snapshot_name,
             target,

--- a/crates/agt/src/main.rs
+++ b/crates/agt/src/main.rs
@@ -48,6 +48,11 @@ fn main() -> Result<()> {
             .with_context(|| format!("Failed to change to directory: {}", dir.display()))?;
     }
 
+    // Handle commands that do not require an existing repository.
+    if let Some(Commands::Setup { store }) = cli.command.clone() {
+        return snapshot::setup(store.as_deref());
+    }
+
     // Handle init command before discovering repo (init doesn't need existing repo)
     if let Some(Commands::Clone { remote_url, path }) = cli.command.clone() {
         let config = config::AgtConfig::load_for_init();
@@ -69,6 +74,7 @@ fn main() -> Result<()> {
 
     // Route to appropriate command handler
     match cli.command {
+        Some(Commands::Setup { .. }) => unreachable!(),
         Some(Commands::Clone { .. }) => unreachable!(), // handled above
         Some(Commands::Session(session_cmd)) => commands::session::run(&repo, session_cmd, &config),
         Some(Commands::Autocommit {
@@ -109,7 +115,7 @@ fn should_show_own_version(args: &[String]) -> bool {
 }
 
 fn print_own_version() {
-    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("AGT_BUILD_VERSION"));
 }
 
 fn run_git_mode() -> Result<()> {

--- a/crates/agt/src/snapshot.rs
+++ b/crates/agt/src/snapshot.rs
@@ -112,16 +112,47 @@ pub fn save(
     Ok(())
 }
 
+pub fn setup(store: Option<&Path>) -> Result<()> {
+    let current_dir = std::env::current_dir()?;
+    let store_path = resolve_store_path(store, &current_dir)?;
+
+    ensure_store_directory(&store_path)?;
+
+    if let Some(repo_root) = discover_repo_root(&current_dir)? {
+        ensure_store_ignored(&repo_root, &store_path)?;
+    }
+
+    println!("Snapshot store ready at {}", store_path.display());
+    Ok(())
+}
+
+fn is_timestamp_tag(tag: &str) -> Option<u64> {
+    let digits: String = tag.chars().filter(|c| c.is_ascii_digit()).collect();
+    if digits.len() >= 17 {
+        digits.parse::<u64>().ok()
+    } else {
+        None
+    }
+}
+
 pub fn check(_repo: &Repository, before: &str, after: &str, store: Option<&Path>) -> Result<()> {
     ensure_supported_platform()?;
     let current_dir = std::env::current_dir()?;
     let store_path = resolve_store_path(store, &current_dir)?;
     let snapshot_repo = open_snapshot_repo(&store_path)?;
-    let before_manifest = load_manifest_for_tag(&snapshot_repo, before)?;
-    let after_manifest = load_manifest_for_tag(&snapshot_repo, after)?;
+
+    let (sorted_before, sorted_after) = match (is_timestamp_tag(before), is_timestamp_tag(after)) {
+        (Some(before_ts), Some(after_ts)) if before_ts > after_ts => {
+            (after.to_string(), before.to_string())
+        }
+        _ => (before.to_string(), after.to_string()),
+    };
+
+    let before_manifest = load_manifest_for_tag(&snapshot_repo, &sorted_before)?;
+    let after_manifest = load_manifest_for_tag(&snapshot_repo, &sorted_after)?;
     let diff = diff_manifests(&before_manifest, &after_manifest);
 
-    println!("Comparing {before} -> {after}");
+    println!("Comparing {} -> {}", sorted_before, sorted_after);
     emit_diff(&diff);
     Ok(())
 }
@@ -160,6 +191,30 @@ pub fn status(_repo: &Repository, store: Option<&Path>, quiet: u8) -> Result<()>
     if diff.is_empty() {
         println!("Clean");
     }
+    Ok(())
+}
+
+pub fn list(_repo: &Repository, store: Option<&Path>) -> Result<()> {
+    ensure_supported_platform()?;
+    let current_dir = std::env::current_dir()?;
+    let store_path = resolve_store_path(store, &current_dir)?;
+    let snapshot_repo = open_snapshot_repo(&store_path)?;
+
+    let mut tags: Vec<String> = Vec::new();
+    for reference in snapshot_repo.references()?.tags()? {
+        let reference = reference.map_err(|err| anyhow::anyhow!(err.to_string()))?;
+        let full_name = reference.name().as_bstr().to_string();
+        let Some(short_name) = full_name.strip_prefix("refs/tags/") else {
+            continue;
+        };
+        tags.push(short_name.to_string());
+    }
+
+    tags.sort();
+    for tag in &tags {
+        println!("{tag}");
+    }
+    println!("\n{} snapshot(s)", tags.len());
     Ok(())
 }
 
@@ -289,6 +344,24 @@ fn open_or_init_snapshot_repo(path: &Path) -> Result<Repository> {
     Ok(gix::init_bare(path)?)
 }
 
+fn ensure_store_directory(path: &Path) -> Result<()> {
+    if path.exists() {
+        if path.is_dir() {
+            return Ok(());
+        }
+        bail!(
+            "Snapshot store {} exists but is not a directory",
+            path.display()
+        );
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::create_dir_all(path)?;
+    Ok(())
+}
+
 fn open_snapshot_repo(path: &Path) -> Result<Repository> {
     gix::open(path).with_context(|| format!("Failed to open snapshot store {}", path.display()))
 }
@@ -347,6 +420,57 @@ fn warn_if_store_not_ignored(
             Ok(())
         }
     }
+}
+
+fn discover_repo_root(current_dir: &Path) -> Result<Option<PathBuf>> {
+    match gix::discover(current_dir) {
+        Ok(repo) => Ok(repo
+            .work_dir()
+            .map(|path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf()))),
+        Err(_) => Ok(None),
+    }
+}
+
+fn ensure_store_ignored(repo_root: &Path, store_path: &Path) -> Result<()> {
+    let store_abs = store_path
+        .canonicalize()
+        .unwrap_or_else(|_| store_path.to_path_buf());
+    if !store_abs.starts_with(repo_root) {
+        return Ok(());
+    }
+
+    let rel = store_abs
+        .strip_prefix(repo_root)
+        .with_context(|| format!("{} is outside {}", store_abs.display(), repo_root.display()))?;
+    if rel.as_os_str().is_empty() {
+        bail!("Snapshot store cannot be the repository root")
+    }
+
+    let ignore_entry = ignore_entry_for(rel);
+    let gitignore_path = repo_root.join(".gitignore");
+    let mut lines = if gitignore_path.exists() {
+        fs::read_to_string(&gitignore_path)?
+            .lines()
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    if lines.iter().any(|line| line.trim() == ignore_entry) {
+        return Ok(());
+    }
+
+    lines.push(ignore_entry.to_string());
+    let mut contents = lines.join("\n");
+    contents.push('\n');
+    fs::write(gitignore_path, contents)?;
+    Ok(())
+}
+
+fn ignore_entry_for(path: &Path) -> String {
+    let normalized = normalize_rel_path(path);
+    format!("{normalized}/")
 }
 
 fn capture_records(

--- a/crates/agt/tests/build_version_support_tests.rs
+++ b/crates/agt/tests/build_version_support_tests.rs
@@ -1,0 +1,42 @@
+#[path = "../../../build/build_version_support.rs"]
+mod build_version_support;
+
+#[test]
+fn release_refs_require_release_prefix_and_numeric_semver() {
+    assert_eq!(
+        build_version_support::parse_release_ref("release/0.1.0"),
+        Some("0.1.0")
+    );
+    assert_eq!(
+        build_version_support::parse_release_ref("release/0.1.0-rc1"),
+        Some("0.1.0-rc1")
+    );
+    assert_eq!(
+        build_version_support::parse_release_ref("release/v0.1.0"),
+        None
+    );
+    assert_eq!(
+        build_version_support::parse_release_ref("release/test-001"),
+        None
+    );
+}
+
+#[test]
+fn nightly_versions_use_date_then_sha() {
+    assert_eq!(
+        build_version_support::format_nightly_version("2026.03.22", "abcdef123456"),
+        "2026.03.22-abcdef123456"
+    );
+}
+
+#[test]
+fn local_versions_use_cargo_base_sha_and_optional_dirty_suffix() {
+    assert_eq!(
+        build_version_support::format_local_version("0.1.0", "abcdef123456", false),
+        "0.1.0-abcdef123456"
+    );
+    assert_eq!(
+        build_version_support::format_local_version("0.1.0", "abcdef123456", true),
+        "0.1.0-abcdef123456+dirty"
+    );
+}

--- a/crates/agt/tests/integration_tests.rs
+++ b/crates/agt/tests/integration_tests.rs
@@ -636,7 +636,7 @@ fn test_snapshot_check_reports_changes_between_snapshots() -> Result<(), Box<dyn
     let after = parse_snapshot_tag(&String::from_utf8(second.stdout)?);
 
     let output = agt_cmd_with_git()?
-        .args(["snapshot", "check", "--before", &before, "--after", &after])
+        .args(["snapshot", "diff", &before, &after])
         .current_dir(repo.worktree())
         .output()?;
     assert!(output.status.success());
@@ -645,6 +645,100 @@ fn test_snapshot_check_reports_changes_between_snapshots() -> Result<(), Box<dyn
     assert!(stdout.contains("D README.md"));
     assert!(stdout.contains("M tracked.txt"));
 
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_snapshot_check_reports_deletions_ignoring_gitignore(
+) -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_check_reports_deletions_ignoring_gitignore");
+    let temp_dir = tempfile::tempdir()?;
+    let repo_path = temp_dir.path();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(repo_path)
+        .output()?;
+    fs::write(repo_path.join(".gitignore"), "_generated/\n")?;
+    fs::write(repo_path.join("tracked.txt"), "tracked")?;
+    fs::create_dir_all(repo_path.join("_generated"))?;
+    fs::write(repo_path.join("_generated/artifact.js"), "console.log(1);")?;
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo_path)
+        .output()?;
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(repo_path)
+        .output()?;
+    write_agt_config(repo_path, "agt@local", "agtsessions/")?;
+    let first = agt_cmd_with_git()?
+        .args(["snapshot", "save"])
+        .current_dir(repo_path)
+        .output()?;
+    assert!(first.status.success());
+    let before = parse_snapshot_tag(&String::from_utf8(first.stdout)?);
+    fs::remove_file(repo_path.join("_generated/artifact.js"))?;
+    let second = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", "after"])
+        .current_dir(repo_path)
+        .output()?;
+    assert!(second.status.success());
+    let after = parse_snapshot_tag(&String::from_utf8(second.stdout)?);
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "diff", &before, &after])
+        .current_dir(repo_path)
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("D _generated/artifact.js"),
+        "expected deletion of gitignored file, got: {stdout}"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_snapshot_diff_auto_sorts_timestamp_tags() -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_diff_auto_sorts_timestamp_tags");
+    let temp_dir = tempfile::tempdir()?;
+    let repo_path = temp_dir.path();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(repo_path)
+        .output()?;
+    fs::write(repo_path.join(".gitignore"), ".agt-snapshots/\n")?;
+    fs::write(repo_path.join("file.txt"), "v1")?;
+    write_agt_config(repo_path, "agt@local", "agtsessions/")?;
+    let first = agt_cmd_with_git()?
+        .args(["snapshot", "save"])
+        .current_dir(repo_path)
+        .output()?;
+    assert!(first.status.success());
+    let older = parse_snapshot_tag(&String::from_utf8(first.stdout)?);
+    fs::write(repo_path.join("file.txt"), "v2")?;
+    fs::write(repo_path.join("new.txt"), "new")?;
+    let second = agt_cmd_with_git()?
+        .args(["snapshot", "save"])
+        .current_dir(repo_path)
+        .output()?;
+    assert!(second.status.success());
+    let newer = parse_snapshot_tag(&String::from_utf8(second.stdout)?);
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "diff", &newer, &older])
+        .current_dir(repo_path)
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("A new.txt"),
+        "reversed order should still show additions correctly, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("D new.txt"),
+        "should not show deletions when newer is before, got: {stdout}"
+    );
     Ok(())
 }
 

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -86,6 +86,31 @@ CONFIGURATION
 COMMANDS
    AGT-SPECIFIC COMMANDS (agt mode only)
 
+       agt setup [--store <path>]
+              Bootstrap standalone snapshot storage for the current directory.
+
+              This command:
+              1. Resolves the standalone snapshot store path
+              2. Creates the store directory if it does not already exist
+              3. If inside a Git worktree, ensures the store is ignored relative
+                 to the repository root
+              4. Leaves existing configuration unchanged when setup is already in place
+
+              By default the store is `.agt-snapshots/` under the current working
+              directory. If `--store` is provided, that path is used instead.
+
+              If the chosen store path is inside the current Git repository, agt
+              ensures the repository root `.gitignore` contains an entry for that
+              store path. If the store path is outside the repository, agt does not
+              edit `.gitignore`.
+
+              This command is intentionally narrow in scope. It only bootstraps the
+              standalone snapshot store and related ignore entry; it does not create
+              or update unrelated AGT configuration.
+
+              Options:
+                  --store <path>         Snapshot store directory to bootstrap
+
        agt clone <remote-url> [--path <directory>]
               Clone a remote repository into an agt-managed structure. This command:
 
@@ -234,10 +259,11 @@ COMMANDS
               5. Records additional filesystem metadata in a snapshot manifest blob
               6. Creates an annotated tag named from the Unix epoch of the snapshot
 
-              By default the snapshot store lives in .agt-snapshots/ under the
-              current working directory. The store location can be overridden by
-              --store or AGT_SNAPSHOT_STORE. agt warns if the chosen store path is
-              not ignored by Git.
+               By default the snapshot store lives in .agt-snapshots/ under the
+               current working directory. The store location can be overridden by
+               --store or AGT_SNAPSHOT_STORE. agt warns if the chosen store path is
+               not ignored by Git. `agt setup` can create the store and ensure the
+               default or chosen in-repo store path is ignored before the first save.
 
               The snapshot manifest records, at minimum:
               • object_id
@@ -253,13 +279,15 @@ COMMANDS
                   --store <path>         Snapshot store directory
                   -m, --message <text>   Annotated tag message
 
-       agt snapshot check --before <tag> --after <tag> [--store <path>]
-              Compare two saved standalone snapshots and report added, deleted,
-              and modified paths.
+       agt snapshot diff <snapshot-a> <snapshot-b> [--store <path>]
+              Compare two saved standalone snapshots and report deleted, modified,
+              and added paths.
+
+              The two snapshot identifiers are positional arguments. Swapping them
+              is allowed; it only changes which direction additions and deletions
+              are reported.
 
               Options:
-                  --before <tag>         Earlier snapshot tag (required)
-                  --after <tag>          Later snapshot tag (required)
                   --store <path>         Snapshot store directory
 
        agt snapshot status [-q] [-q] [--store <path>]
@@ -381,6 +409,13 @@ OPTIONS
        --version
                When invoked as `agt`, print agt's own version string.
 
+               The reported version is embedded at build time:
+               - release tags `release/X.Y.Z` or `release/X.Y.Z-suffix`
+                 report `X.Y.Z` or `X.Y.Z-suffix`
+               - nightly builds from `main` report `YYYY.MM.DD-<shortsha>`
+               - local development builds report `<cargo-base-version>-<shortsha>`
+                 and append `+dirty` when the worktree or index is dirty
+
                When invoked as `git`, delegate `--version` to the configured
                real git binary so the reported version matches the host git.
 
@@ -473,11 +508,17 @@ EXAMPLES
         Auto-commit agent changes:
                $ agt autocommit -C sessions/agent-001 --session-id agent-001
 
+        Bootstrap the default standalone snapshot store for the current repository:
+               $ agt setup
+
+        Bootstrap a custom standalone snapshot store path:
+               $ agt setup --store tmp/agt-store
+
         Save a standalone snapshot of the current tree:
                $ agt snapshot save -m "before agent run"
 
         Compare two standalone snapshots:
-               $ agt snapshot check --before 01739800000000000000 --after 01739800001234567890
+               $ agt snapshot diff 01739800000000000000 01739800001234567890
 
         Ask whether anything changed since the latest standalone snapshot:
                $ agt snapshot status -q

--- a/scripts/setup-windows-ci-emulation.sh
+++ b/scripts/setup-windows-ci-emulation.sh
@@ -14,7 +14,11 @@ rm -rf "$HARNESS_ROOT"
 mkdir -p "$WORKSPACE" "$RUNNER_TEMP"
 
 echo "=== Mirroring workspace into fake GitHub runner path ==="
-git archive HEAD | tar -x -C "$WORKSPACE"
+rsync -a --delete \
+	--exclude target \
+	--exclude dist \
+	--exclude .tmp \
+	"$(git rev-parse --show-toplevel)/" "$WORKSPACE/"
 
 echo "=== Building release binary ==="
 cargo build --release --manifest-path "$WORKSPACE/Cargo.toml"


### PR DESCRIPTION
## Summary

- Rename  to  with positional arguments (issue #24)
- Add auto-sort for timestamp-based snapshot tags (issue #25)  
- Add  command to list saved snapshots (issue #23)
- Remove deprecated  command entirely (0.x version)
- Update docs to reflect new syntax

## Testing

- All snapshot tests pass
- Tested auto-sort with reversed timestamps
- Tested list command on livemore-pricing-engine