### PR TITLE
fix: restore green CI and align 0.2.0 release state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,22 @@ jobs:
           pattern: release-*
           merge-multiple: true
           path: release-assets
+      - name: Ensure nightly tag points at current main commit
+        if: needs.release-meta.outputs.release_kind == 'nightly'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh api \
+            --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" \
+            -f sha="${GITHUB_SHA}" \
+            -F force=true \
+          || gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref='refs/tags/nightly' \
+            -f sha="${GITHUB_SHA}"
       - name: Create or refresh draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -292,15 +308,11 @@ jobs:
         shell: bash
         run: |
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            if [[ "$RELEASE_KIND" == "nightly" ]]; then
-              gh release delete "$RELEASE_TAG" --yes --cleanup-tag
-            else
-              gh release delete "$RELEASE_TAG" --yes
-            fi
+            gh release delete "$RELEASE_TAG" --yes
           fi
 
           gh release create "$RELEASE_TAG" \
-            --target "$GITHUB_SHA" \
+            --verify-tag \
             --title "$RELEASE_TITLE" \
             --notes "$RELEASE_NOTES" \
             --draft

--- a/CODING_PROMPT.md
+++ b/CODING_PROMPT.md
@@ -39,7 +39,7 @@ Also create at project root:
 ```toml
 [package]
 name = "agt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agt-worktree"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["AI Coding Agent"]
 license = "MIT"
 

--- a/bin/pyproject.toml
+++ b/bin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agt-bin"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.11"
 dependencies = [
     "markdown>=3.5",

--- a/build/build_version_support.rs
+++ b/build/build_version_support.rs
@@ -1,3 +1,17 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BuildChannel {
+    Local,
+    Nightly,
+}
+
+pub fn parse_build_channel(value: Option<&str>) -> Result<BuildChannel, String> {
+    match value {
+        Some("nightly") => Ok(BuildChannel::Nightly),
+        Some("") | None => Ok(BuildChannel::Local),
+        Some(other) => Err(format!("unsupported AGT_BUILD_CHANNEL: {other}")),
+    }
+}
+
 pub fn parse_release_ref(ref_name: &str) -> Option<&str> {
     let version = ref_name.strip_prefix("release/")?;
     if is_valid_release_version(version) {
@@ -58,26 +72,41 @@ fn is_valid_suffix(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_local_version, format_nightly_version, is_valid_release_version, parse_release_ref,
+        format_local_version, format_nightly_version, is_valid_release_version,
+        parse_build_channel, parse_release_ref, BuildChannel,
     };
 
     #[test]
+    fn parses_build_channels() {
+        assert_eq!(parse_build_channel(None), Ok(BuildChannel::Local));
+        assert_eq!(parse_build_channel(Some("")), Ok(BuildChannel::Local));
+        assert_eq!(
+            parse_build_channel(Some("nightly")),
+            Ok(BuildChannel::Nightly)
+        );
+        assert_eq!(
+            parse_build_channel(Some("bogus")),
+            Err(String::from("unsupported AGT_BUILD_CHANNEL: bogus"))
+        );
+    }
+
+    #[test]
     fn parses_release_refs() {
-        assert_eq!(parse_release_ref("release/0.1.0"), Some("0.1.0"));
-        assert_eq!(parse_release_ref("release/0.1.0-rc1"), Some("0.1.0-rc1"));
-        assert_eq!(parse_release_ref("0.1.0"), None);
-        assert_eq!(parse_release_ref("release/v0.1.0"), None);
+        assert_eq!(parse_release_ref("release/0.2.0"), Some("0.2.0"));
+        assert_eq!(parse_release_ref("release/0.2.0-rc1"), Some("0.2.0-rc1"));
+        assert_eq!(parse_release_ref("0.2.0"), None);
+        assert_eq!(parse_release_ref("release/v0.2.0"), None);
     }
 
     #[test]
     fn validates_release_versions() {
-        assert!(is_valid_release_version("0.1.0"));
+        assert!(is_valid_release_version("0.2.0"));
         assert!(is_valid_release_version("12.34.56-rc1"));
         assert!(is_valid_release_version("12.34.56-rc.1"));
-        assert!(!is_valid_release_version("v0.1.0"));
+        assert!(!is_valid_release_version("v0.2.0"));
         assert!(!is_valid_release_version("0.1"));
-        assert!(!is_valid_release_version("0.1.0-"));
-        assert!(!is_valid_release_version("0.1.0+build"));
+        assert!(!is_valid_release_version("0.2.0-"));
+        assert!(!is_valid_release_version("0.2.0+build"));
     }
 
     #[test]
@@ -87,12 +116,12 @@ mod tests {
             "2026.03.22-abcdef123456"
         );
         assert_eq!(
-            format_local_version("0.1.0", "abcdef123456", false),
-            "0.1.0-abcdef123456"
+            format_local_version("0.2.0", "abcdef123456", false),
+            "0.2.0-abcdef123456"
         );
         assert_eq!(
-            format_local_version("0.1.0", "abcdef123456", true),
-            "0.1.0-abcdef123456+dirty"
+            format_local_version("0.2.0", "abcdef123456", true),
+            "0.2.0-abcdef123456+dirty"
         );
     }
 }

--- a/crates/agt-worktree/Cargo.toml
+++ b/crates/agt-worktree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt-worktree"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Minimal worktree add/remove helper for agt"

--- a/crates/agt-worktree/build.rs
+++ b/crates/agt-worktree/build.rs
@@ -20,15 +20,18 @@ fn main() {
         .map(|status| !status.is_empty())
         .unwrap_or(false);
 
-    let version = match env::var("AGT_BUILD_CHANNEL").ok().as_deref() {
-        Some("nightly") => {
+    let version = match build_version_support::parse_build_channel(
+        env::var("AGT_BUILD_CHANNEL").ok().as_deref(),
+    )
+    .unwrap_or_else(|err| panic!("{err}"))
+    {
+        build_version_support::BuildChannel::Nightly => {
             let build_date = env::var("AGT_BUILD_DATE")
                 .expect("AGT_BUILD_DATE must be set when AGT_BUILD_CHANNEL=nightly");
             let sha = short_sha.clone().unwrap_or_else(|| String::from("unknown"));
             build_version_support::format_nightly_version(&build_date, &sha)
         }
-        Some(other) => panic!("unsupported AGT_BUILD_CHANNEL: {other}"),
-        None => {
+        build_version_support::BuildChannel::Local => {
             if !dirty {
                 if let Some(version) = exact_release_version() {
                     version

--- a/crates/agt/Cargo.toml
+++ b/crates/agt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["AI Coding Agent"]
 license = "MIT"

--- a/crates/agt/build.rs
+++ b/crates/agt/build.rs
@@ -20,15 +20,18 @@ fn main() {
         .map(|status| !status.is_empty())
         .unwrap_or(false);
 
-    let version = match env::var("AGT_BUILD_CHANNEL").ok().as_deref() {
-        Some("nightly") => {
+    let version = match build_version_support::parse_build_channel(
+        env::var("AGT_BUILD_CHANNEL").ok().as_deref(),
+    )
+    .unwrap_or_else(|err| panic!("{err}"))
+    {
+        build_version_support::BuildChannel::Nightly => {
             let build_date = env::var("AGT_BUILD_DATE")
                 .expect("AGT_BUILD_DATE must be set when AGT_BUILD_CHANNEL=nightly");
             let sha = short_sha.clone().unwrap_or_else(|| String::from("unknown"));
             build_version_support::format_nightly_version(&build_date, &sha)
         }
-        Some(other) => panic!("unsupported AGT_BUILD_CHANNEL: {other}"),
-        None => {
+        build_version_support::BuildChannel::Local => {
             if !dirty {
                 if let Some(version) = exact_release_version() {
                     version

--- a/crates/agt/tests/build_version_support_tests.rs
+++ b/crates/agt/tests/build_version_support_tests.rs
@@ -4,15 +4,15 @@ mod build_version_support;
 #[test]
 fn release_refs_require_release_prefix_and_numeric_semver() {
     assert_eq!(
-        build_version_support::parse_release_ref("release/0.1.0"),
-        Some("0.1.0")
+        build_version_support::parse_release_ref("release/0.2.0"),
+        Some("0.2.0")
     );
     assert_eq!(
-        build_version_support::parse_release_ref("release/0.1.0-rc1"),
-        Some("0.1.0-rc1")
+        build_version_support::parse_release_ref("release/0.2.0-rc1"),
+        Some("0.2.0-rc1")
     );
     assert_eq!(
-        build_version_support::parse_release_ref("release/v0.1.0"),
+        build_version_support::parse_release_ref("release/v0.2.0"),
         None
     );
     assert_eq!(
@@ -32,11 +32,31 @@ fn nightly_versions_use_date_then_sha() {
 #[test]
 fn local_versions_use_cargo_base_sha_and_optional_dirty_suffix() {
     assert_eq!(
-        build_version_support::format_local_version("0.1.0", "abcdef123456", false),
-        "0.1.0-abcdef123456"
+        build_version_support::format_local_version("0.2.0", "abcdef123456", false),
+        "0.2.0-abcdef123456"
     );
     assert_eq!(
-        build_version_support::format_local_version("0.1.0", "abcdef123456", true),
-        "0.1.0-abcdef123456+dirty"
+        build_version_support::format_local_version("0.2.0", "abcdef123456", true),
+        "0.2.0-abcdef123456+dirty"
+    );
+}
+
+#[test]
+fn build_channels_treat_empty_as_local_and_reject_unknown_values() {
+    assert_eq!(
+        build_version_support::parse_build_channel(None),
+        Ok(build_version_support::BuildChannel::Local)
+    );
+    assert_eq!(
+        build_version_support::parse_build_channel(Some("")),
+        Ok(build_version_support::BuildChannel::Local)
+    );
+    assert_eq!(
+        build_version_support::parse_build_channel(Some("nightly")),
+        Ok(build_version_support::BuildChannel::Nightly)
+    );
+    assert_eq!(
+        build_version_support::parse_build_channel(Some("bogus")),
+        Err(String::from("unsupported AGT_BUILD_CHANNEL: bogus"))
     );
 }

--- a/crates/agt/tests/integration_tests.rs
+++ b/crates/agt/tests/integration_tests.rs
@@ -14,6 +14,10 @@ fn agt_bin() -> PathBuf {
     assert_cmd::cargo::cargo_bin!("agt").to_path_buf()
 }
 
+fn expected_agt_version_line() -> String {
+    format!("agt {}", env!("AGT_BUILD_VERSION"))
+}
+
 #[allow(dead_code)]
 fn log_test_start(test_name: &str) {
     if std::env::var("AGT_LOG").is_ok() {
@@ -233,7 +237,7 @@ fn test_agt_mode_version_shows_own_version() -> Result<(), Box<dyn std::error::E
         .output()?;
 
     let stdout = String::from_utf8(output.stdout)?;
-    assert_eq!(stdout.trim(), format!("agt {}", env!("CARGO_PKG_VERSION")));
+    assert_eq!(stdout.trim(), expected_agt_version_line());
 
     Ok(())
 }
@@ -257,7 +261,7 @@ fn test_git_mode_version_delegates_to_host_git() -> Result<(), Box<dyn std::erro
 
     let stdout = String::from_utf8(output.stdout)?;
     assert!(stdout.contains("mock git version 9.9.9"));
-    assert!(!stdout.contains(&format!("agt {}", env!("CARGO_PKG_VERSION"))));
+    assert!(!stdout.contains(&expected_agt_version_line()));
 
     Ok(())
 }
@@ -283,7 +287,7 @@ fn test_git_mode_version_delegates_even_if_parent_path_contains_agt(
 
     let stdout = String::from_utf8(output.stdout)?;
     assert!(stdout.contains("mock git version 9.9.9"));
-    assert!(!stdout.contains(&format!("agt {}", env!("CARGO_PKG_VERSION"))));
+    assert!(!stdout.contains(&expected_agt_version_line()));
 
     Ok(())
 }
@@ -307,7 +311,7 @@ fn test_agt_show_own_version_overrides_git_mode() -> Result<(), Box<dyn std::err
         .output()?;
 
     let stdout = String::from_utf8(output.stdout)?;
-    assert_eq!(stdout.trim(), format!("agt {}", env!("CARGO_PKG_VERSION")));
+    assert_eq!(stdout.trim(), expected_agt_version_line());
     assert!(!stdout.contains("mock git version 9.9.9"));
 
     Ok(())
@@ -325,7 +329,7 @@ fn test_agt_show_own_version_keeps_agt_mode_version() -> Result<(), Box<dyn std:
         .output()?;
 
     let stdout = String::from_utf8(output.stdout)?;
-    assert_eq!(stdout.trim(), format!("agt {}", env!("CARGO_PKG_VERSION")));
+    assert_eq!(stdout.trim(), expected_agt_version_line());
 
     Ok(())
 }

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -629,4 +629,4 @@ BUGS
 AUTHOR
        Written for AI agent session management and immutable filesystem workflows.
 
-AGT 0.1.0                         January 2026                          AGT(1)
+AGT 0.2.0                         January 2026                          AGT(1)


### PR DESCRIPTION
## Summary
- restore green CI by treating empty `AGT_BUILD_CHANNEL` as local builds and fixing version assertions to follow the actual build version
- align workspace/package docs and manifests with the reachable `release/0.2.0` base so hooks, builds, and release metadata agree
- repair nightly draft release publishing by ensuring the `nightly` tag exists before creating the release

Closes #30.

## Verification
- cargo fmt --all
- env AGT_BUILD_CHANNEL='' cargo clippy --workspace --all-targets --all-features -- -D warnings
- env AGT_BUILD_CHANNEL='' cargo test --workspace --all-targets --all-features -- --nocapture
- env AGT_BUILD_CHANNEL='nightly' AGT_BUILD_DATE='2026.03.23' cargo test --workspace --all-targets --all-features -- --nocapture