### PR TITLE
fix: correct release_tag in CI workflow for semver releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
             fi
             publish=true
             release_kind=semver
-            release_tag="${version}"
+            release_tag="release/${version}"
             release_title="${version}"
             binary_suffix="${version}"
             asset_suffix="${version}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"
-version = "0.2.0"
+version = "2.0.1"
 authors = ["AI Coding Agent"]
 license = "MIT"
 

--- a/bin/pyproject.toml
+++ b/bin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agt-bin"
-version = "0.2.0"
+version = "2.0.1"
 requires-python = ">=3.11"
 dependencies = [
     "markdown>=3.5",

--- a/crates/agt-worktree/Cargo.toml
+++ b/crates/agt-worktree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt-worktree"
-version = "0.2.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT"
 description = "Minimal worktree add/remove helper for agt"

--- a/crates/agt/Cargo.toml
+++ b/crates/agt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt"
-version = "0.2.0"
+version = "2.0.1"
 edition = "2021"
 authors = ["AI Coding Agent"]
 license = "MIT"

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -629,4 +629,4 @@ BUGS
 AUTHOR
        Written for AI agent session management and immutable filesystem workflows.
 
-AGT 0.2.0                         January 2026                          AGT(1)
+AGT 2.0.1                         January 2026                          AGT(1)


### PR DESCRIPTION
## Summary
- Fix CI workflow `release_tag` to include `release/` prefix for semver releases
- Bump version to 2.0.1
- Update man page

Fixes #30