### PR TITLE
fix: allow forward semver versions for release workflow

### DIFF
--- a/.githooks/validate-version.sh
+++ b/.githooks/validate-version.sh
@@ -22,6 +22,28 @@ esac
 
 latest_base=${latest_version%%-*}
 
+parse_base_version() {
+	case "$1" in
+	[0-9]*.[0-9]*.[0-9]*-*)
+		echo "${1%%-*}"
+		;;
+	*)
+		echo "$1"
+		;;
+	esac
+}
+
+is_newer_or_equal() {
+	current_base=$1
+	latest_base=$2
+
+	if [ "$(printf '%s\n%s\n' "$latest_base" "$current_base" | sort -V | head -n1)" != "$latest_base" ]; then
+		echo "no"
+	else
+		echo "yes"
+	fi
+}
+
 read_version() {
 	awk -F '"' '/^version = "/ { print $2; exit }' "$1"
 }
@@ -34,8 +56,10 @@ check_version_file() {
 		exit 1
 	fi
 
-	if [ "$current_version" != "$latest_base" ]; then
-		printf '%s\n' "ERROR: $file version $current_version does not match latest reachable release base $latest_base ($latest_tag)" >&2
+	current_base=$(parse_base_version "$current_version")
+
+	if [ "$(is_newer_or_equal "$current_base" "$latest_base")" != "yes" ]; then
+		printf '%s\n' "ERROR: $file version $current_version is older than latest reachable release base $latest_base ($latest_tag)" >&2
 		exit 1
 	fi
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
             fi
             publish=true
             release_kind=semver
-            release_tag="${version}"
+            release_tag="release/${version}"
             release_title="${version}"
             binary_suffix="${version}"
             asset_suffix="${version}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agt-worktree"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"
-version = "2.0.1"
+version = "0.2.1"
 authors = ["AI Coding Agent"]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"
-version = "0.2.0"
+version = "2.0.1"
 authors = ["AI Coding Agent"]
 license = "MIT"
 

--- a/bin/pyproject.toml
+++ b/bin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agt-bin"
-version = "0.2.0"
+version = "2.0.1"
 requires-python = ">=3.11"
 dependencies = [
     "markdown>=3.5",

--- a/bin/pyproject.toml
+++ b/bin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agt-bin"
-version = "2.0.1"
+version = "0.2.1"
 requires-python = ">=3.11"
 dependencies = [
     "markdown>=3.5",

--- a/crates/agt-worktree/Cargo.toml
+++ b/crates/agt-worktree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt-worktree"
-version = "0.2.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT"
 description = "Minimal worktree add/remove helper for agt"

--- a/crates/agt-worktree/Cargo.toml
+++ b/crates/agt-worktree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt-worktree"
-version = "2.0.1"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Minimal worktree add/remove helper for agt"

--- a/crates/agt/Cargo.toml
+++ b/crates/agt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt"
-version = "0.2.0"
+version = "2.0.1"
 edition = "2021"
 authors = ["AI Coding Agent"]
 license = "MIT"

--- a/crates/agt/Cargo.toml
+++ b/crates/agt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt"
-version = "2.0.1"
+version = "0.2.1"
 edition = "2021"
 authors = ["AI Coding Agent"]
 license = "MIT"

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -629,4 +629,4 @@ BUGS
 AUTHOR
        Written for AI agent session management and immutable filesystem workflows.
 
-AGT 0.2.0                         January 2026                          AGT(1)
+AGT 2.0.1                         January 2026                          AGT(1)

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -629,4 +629,4 @@ BUGS
 AUTHOR
        Written for AI agent session management and immutable filesystem workflows.
 
-AGT 2.0.1                         January 2026                          AGT(1)
+AGT 0.2.1                         January 2026                          AGT(1)


### PR DESCRIPTION
## Summary
- Fix version validation hook to allow forward semver versions (for example 0.2.1 vs tag release/0.2.0)
- Bump release metadata versions to 0.2.1
- Keep semver release tag handling in CI aligned with release/ prefix

Fixes #30
