### PR TITLE
feat: snapshot list shows tag messages by default with -q for quiet mode

### DIFF
--- a/crates/agt/src/cli.rs
+++ b/crates/agt/src/cli.rs
@@ -109,6 +109,9 @@ pub enum SnapshotCommands {
 
     /// List saved standalone snapshots
     List {
+        /// Reduce output; show only tags without messages
+        #[arg(short = 'q', action = ArgAction::Count)]
+        quiet: u8,
         /// Override snapshot store location
         #[arg(long)]
         store: Option<PathBuf>,

--- a/crates/agt/src/commands/snapshot.rs
+++ b/crates/agt/src/commands/snapshot.rs
@@ -19,7 +19,7 @@ pub fn run(repo: &Repository, command: SnapshotCommands, config: &AgtConfig) -> 
         SnapshotCommands::Status { store, quiet } => {
             snapshot::status(repo, store.as_deref(), quiet)
         }
-        SnapshotCommands::List { store } => snapshot::list(repo, store.as_deref()),
+        SnapshotCommands::List { quiet, store } => snapshot::list(repo, store.as_deref(), quiet),
         SnapshotCommands::Restore {
             snapshot: snapshot_name,
             target,

--- a/crates/agt/src/snapshot.rs
+++ b/crates/agt/src/snapshot.rs
@@ -194,25 +194,57 @@ pub fn status(_repo: &Repository, store: Option<&Path>, quiet: u8) -> Result<()>
     Ok(())
 }
 
-pub fn list(_repo: &Repository, store: Option<&Path>) -> Result<()> {
+pub fn list(_repo: &Repository, store: Option<&Path>, quiet: u8) -> Result<()> {
     ensure_supported_platform()?;
     let current_dir = std::env::current_dir()?;
     let store_path = resolve_store_path(store, &current_dir)?;
     let snapshot_repo = open_snapshot_repo(&store_path)?;
 
-    let mut tags: Vec<String> = Vec::new();
-    for reference in snapshot_repo.references()?.tags()? {
-        let reference = reference.map_err(|err| anyhow::anyhow!(err.to_string()))?;
+    let mut tags: Vec<(String, Option<String>)> = Vec::new();
+    for reference_result in snapshot_repo.references()?.tags()? {
+        let mut reference = reference_result.map_err(|err| anyhow::anyhow!(err.to_string()))?;
         let full_name = reference.name().as_bstr().to_string();
         let Some(short_name) = full_name.strip_prefix("refs/tags/") else {
             continue;
         };
-        tags.push(short_name.to_string());
+
+        let tag_name = short_name.to_string();
+        let message = if quiet == 0 {
+            if let Ok(commit) = reference.peel_to_commit() {
+                commit.message_raw().ok().and_then(|commit_message| {
+                    commit_message.to_string().lines().next().and_then(|s| {
+                        let trimmed = s.trim_end();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    })
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        tags.push((tag_name, message));
     }
 
-    tags.sort();
-    for tag in &tags {
-        println!("{tag}");
+    tags.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if quiet > 0 {
+        for (tag, _) in &tags {
+            println!("{tag}");
+        }
+    } else {
+        for (tag, msg) in &tags {
+            if let Some(message) = msg {
+                println!("{tag}  {message}");
+            } else {
+                println!("{tag}");
+            }
+        }
     }
     println!("\n{} snapshot(s)", tags.len());
     Ok(())

--- a/crates/agt/tests/integration_tests.rs
+++ b/crates/agt/tests/integration_tests.rs
@@ -659,6 +659,74 @@ fn test_snapshot_list_shows_snapshots() -> Result<(), Box<dyn std::error::Error>
 
 #[cfg(unix)]
 #[test]
+fn test_snapshot_list_shows_messages_by_default() -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_list_shows_messages_by_default");
+    let repo = setup_basic_repo()?;
+    write_agt_config(repo.worktree(), "agt@local", "agtsessions/")?;
+    fs::write(repo.worktree().join("file.txt"), "v1")?;
+
+    let first = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", "first snapshot message"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(first.status.success());
+    let first_tag = parse_snapshot_tag(&String::from_utf8(first.stdout)?);
+
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "list"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(
+        stdout.contains(&first_tag),
+        "expected first tag in list output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("first snapshot message"),
+        "expected message in list output, got: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_snapshot_list_quiet_mode() -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_list_quiet_mode");
+    let repo = setup_basic_repo()?;
+    write_agt_config(repo.worktree(), "agt@local", "agtsessions/")?;
+    fs::write(repo.worktree().join("file.txt"), "v1")?;
+
+    let first = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", "quiet mode test"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(first.status.success());
+    let first_tag = parse_snapshot_tag(&String::from_utf8(first.stdout)?);
+
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "list", "-q"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(
+        stdout.contains(&first_tag),
+        "expected first tag in list output, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("quiet mode test"),
+        "expected message NOT in quiet list output, got: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
 fn test_snapshot_check_reports_changes_between_snapshots() -> Result<(), Box<dyn std::error::Error>>
 {
     log_test_start("test_snapshot_check_reports_changes_between_snapshots");

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -279,7 +279,20 @@ COMMANDS
                   --store <path>         Snapshot store directory
                   -m, --message <text>   Annotated tag message
 
-       agt snapshot diff <snapshot-a> <snapshot-b> [--store <path>]
+        agt snapshot list [-q] [--store <path>]
+               List saved standalone snapshots.
+
+               By default, shows each snapshot tag followed by its message (if any).
+               Use -q (can be repeated) for quieter output:
+
+               • -q
+                      Show only tags, one per line, without messages.
+
+               Options:
+                   -q, -qq              Reduce output (quiet mode)
+                   --store <path>       Snapshot store directory
+
+        agt snapshot diff <snapshot-a> <snapshot-b> [--store <path>]
               Compare two saved standalone snapshots and report deleted, modified,
               and added paths.
 


### PR DESCRIPTION
## Summary
- Add `-q` (quiet) flag to `agt snapshot list` command
- By default, show each tag with its message
- With `-q`: show only tags (current behavior)
- Add documentation in man page
- Add integration tests for new behavior

## Changes
1. **CLI** (`cli.rs`): Add `quiet` field to `List` command
2. **Handler** (`commands/snapshot.rs`): Pass quiet flag to list function
3. **Implementation** (`snapshot.rs`): Read commit message from tag and display
4. **Tests** (`integration_tests.rs`): Test default message display and quiet mode
5. **Docs** (`agt.1.txt`): Document new command behavior

## Example Usage
```
$ agt snapshot list
01774215172985660000  before agent run
01774215308629919000  after debugging
28 snapshot(s)

$ agt snapshot list -q
01774215172985660000
01774215308629919000
28 snapshot(s)
```

Closes #34