### PR TITLE
Issue #37 show snapshot messages in list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agt"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agt-worktree"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["AI Coding Agent"]
 license = "MIT"
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,5 @@ docs:
 	mkdir -p .tmp
 	cd bin && uv sync
 	npm list -g @mermaid-js/mermaid-cli >/dev/null 2>&1 || npm install -g @mermaid-js/mermaid-cli
-	cd bin && uv run ./md2pdf ../DESIGN_20260104.md --pdf ../.tmp/DESIGN_20260104.pdf --svg-dir ../.tmp
-	cd bin && uv run ./md2pdf ../DESIGN_20260105.md --pdf ../.tmp/DESIGN_20260105.pdf --svg-dir ../.tmp
+	cd bin && for design in ../DESIGN_*.md; do name=$$(basename "$$design" .md); uv run ./md2pdf "$$design" --pdf "../.tmp/$$name.pdf" --svg-dir ../.tmp; done
 	@echo "PDFs and SVGs generated in .tmp/"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Key commands:
 - `agt session remove --id <id>` - Remove a session
 - `agt autocommit --session-id <id>` - Capture session shadow history
 - `agt snapshot save` - Save a standalone filesystem snapshot into an isolated store
-- `agt snapshot list` - List standalone snapshots with their saved messages
+- `agt snapshot list [-q]` - List standalone snapshots, with optional tag-only quiet output
 - `agt snapshot diff <snapshot-a> <snapshot-b>` - Compare two standalone snapshots
 - `agt snapshot status` - Compare the current tree against the latest standalone snapshot
 - `agt snapshot restore` - Restore all or part of a saved standalone snapshot

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Key commands:
 - `agt session remove --id <id>` - Remove a session
 - `agt autocommit --session-id <id>` - Capture session shadow history
 - `agt snapshot save` - Save a standalone filesystem snapshot into an isolated store
+- `agt snapshot list` - List standalone snapshots with their saved messages
 - `agt snapshot diff <snapshot-a> <snapshot-b>` - Compare two standalone snapshots
 - `agt snapshot status` - Compare the current tree against the latest standalone snapshot
 - `agt snapshot restore` - Restore all or part of a saved standalone snapshot
@@ -137,6 +138,9 @@ agt setup
 
 # Save a standalone snapshot before running an agent
 agt snapshot save -m "before run"
+
+# List saved standalone snapshots with their messages
+agt snapshot list
 
 # Ask if anything changed since the latest standalone snapshot
 agt snapshot status -q

--- a/bin/pyproject.toml
+++ b/bin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agt-bin"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">=3.11"
 dependencies = [
     "markdown>=3.5",

--- a/crates/agt-worktree/Cargo.toml
+++ b/crates/agt-worktree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt-worktree"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 description = "Minimal worktree add/remove helper for agt"

--- a/crates/agt/Cargo.toml
+++ b/crates/agt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agt"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["AI Coding Agent"]
 license = "MIT"

--- a/crates/agt/src/cli.rs
+++ b/crates/agt/src/cli.rs
@@ -112,6 +112,9 @@ pub enum SnapshotCommands {
         /// Override snapshot store location
         #[arg(long)]
         store: Option<PathBuf>,
+        /// Print only snapshot tags
+        #[arg(short = 'q', long)]
+        quiet: bool,
     },
 
     /// Restore files from a saved snapshot

--- a/crates/agt/src/commands/snapshot.rs
+++ b/crates/agt/src/commands/snapshot.rs
@@ -19,7 +19,7 @@ pub fn run(repo: &Repository, command: SnapshotCommands, config: &AgtConfig) -> 
         SnapshotCommands::Status { store, quiet } => {
             snapshot::status(repo, store.as_deref(), quiet)
         }
-        SnapshotCommands::List { store } => snapshot::list(repo, store.as_deref()),
+        SnapshotCommands::List { store, quiet } => snapshot::list(repo, store.as_deref(), quiet),
         SnapshotCommands::Restore {
             snapshot: snapshot_name,
             target,

--- a/crates/agt/src/snapshot.rs
+++ b/crates/agt/src/snapshot.rs
@@ -1,6 +1,7 @@
 use crate::config::AgtConfig;
 use anyhow::{bail, Context, Result};
 use gix::bstr::BStr;
+use gix::bstr::ByteSlice;
 use gix::object::tree::EntryKind;
 use gix::Repository;
 use gix_object::{compute_hash, Kind, Tree};
@@ -17,6 +18,7 @@ const MANIFEST_PATH: &str = "meta/manifest.bin";
 const PAYLOAD_PREFIX: &str = "payload";
 const MANIFEST_MAGIC: &[u8; 8] = b"AGTSNP01";
 const MANIFEST_VERSION: u32 = 1;
+const SNAPSHOT_LIST_WIDTH: usize = 80;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SnapshotManifest {
@@ -200,22 +202,47 @@ pub fn list(_repo: &Repository, store: Option<&Path>) -> Result<()> {
     let store_path = resolve_store_path(store, &current_dir)?;
     let snapshot_repo = open_snapshot_repo(&store_path)?;
 
-    let mut tags: Vec<String> = Vec::new();
+    let mut tags: Vec<(String, String)> = Vec::new();
     for reference in snapshot_repo.references()?.tags()? {
-        let reference = reference.map_err(|err| anyhow::anyhow!(err.to_string()))?;
+        let mut reference = reference.map_err(|err| anyhow::anyhow!(err.to_string()))?;
         let full_name = reference.name().as_bstr().to_string();
         let Some(short_name) = full_name.strip_prefix("refs/tags/") else {
             continue;
         };
-        tags.push(short_name.to_string());
+        let tag_object = reference.peel_to_tag()?;
+        let tag = tag_object.decode()?;
+        tags.push((
+            short_name.to_string(),
+            normalize_snapshot_message(tag.message.as_bstr().to_string()),
+        ));
     }
 
-    tags.sort();
-    for tag in &tags {
-        println!("{tag}");
+    tags.sort_by(|left, right| left.0.cmp(&right.0));
+    for (tag, message) in &tags {
+        println!("{}", format_snapshot_list_line(tag, message));
     }
     println!("\n{} snapshot(s)", tags.len());
     Ok(())
+}
+
+fn normalize_snapshot_message(message: String) -> String {
+    message.replace('\n', " ").trim().to_string()
+}
+
+fn format_snapshot_list_line(tag: &str, message: &str) -> String {
+    let full_line = format!("{tag} {message}");
+    if full_line.chars().count() <= SNAPSHOT_LIST_WIDTH {
+        return full_line;
+    }
+
+    let prefix = format!("{tag} ");
+    let available = SNAPSHOT_LIST_WIDTH.saturating_sub(prefix.chars().count());
+    if available <= 2 {
+        return prefix;
+    }
+
+    let truncated_message: String = message.chars().take(available - 2).collect();
+    format!("{prefix}{truncated_message}..")
 }
 
 pub fn restore(

--- a/crates/agt/src/snapshot.rs
+++ b/crates/agt/src/snapshot.rs
@@ -196,7 +196,7 @@ pub fn status(_repo: &Repository, store: Option<&Path>, quiet: u8) -> Result<()>
     Ok(())
 }
 
-pub fn list(_repo: &Repository, store: Option<&Path>) -> Result<()> {
+pub fn list(_repo: &Repository, store: Option<&Path>, quiet: bool) -> Result<()> {
     ensure_supported_platform()?;
     let current_dir = std::env::current_dir()?;
     let store_path = resolve_store_path(store, &current_dir)?;
@@ -219,7 +219,11 @@ pub fn list(_repo: &Repository, store: Option<&Path>) -> Result<()> {
 
     tags.sort_by(|left, right| left.0.cmp(&right.0));
     for (tag, message) in &tags {
-        println!("{}", format_snapshot_list_line(tag, message));
+        if quiet {
+            println!("{tag}");
+        } else {
+            println!("{}", format_snapshot_list_line(tag, message));
+        }
     }
     println!("\n{} snapshot(s)", tags.len());
     Ok(())

--- a/crates/agt/src/snapshot.rs
+++ b/crates/agt/src/snapshot.rs
@@ -202,27 +202,34 @@ pub fn list(_repo: &Repository, store: Option<&Path>, quiet: bool) -> Result<()>
     let store_path = resolve_store_path(store, &current_dir)?;
     let snapshot_repo = open_snapshot_repo(&store_path)?;
 
-    let mut tags: Vec<(String, String)> = Vec::new();
+    let mut tags: Vec<(String, Option<String>)> = Vec::new();
     for reference in snapshot_repo.references()?.tags()? {
-        let mut reference = reference.map_err(|err| anyhow::anyhow!(err.to_string()))?;
+        let reference = reference.map_err(|err| anyhow::anyhow!(err.to_string()))?;
         let full_name = reference.name().as_bstr().to_string();
         let Some(short_name) = full_name.strip_prefix("refs/tags/") else {
             continue;
         };
-        let tag_object = reference.peel_to_tag()?;
-        let tag = tag_object.decode()?;
-        tags.push((
-            short_name.to_string(),
-            normalize_snapshot_message(tag.message.as_bstr().to_string()),
-        ));
+        let message = reference.try_id().and_then(|id| {
+            let object = id.object().ok()?;
+            let tag = object.try_to_tag_ref().ok()?;
+            let message = normalize_snapshot_message(tag.message.as_bstr().to_string());
+            if message.is_empty() {
+                None
+            } else {
+                Some(message)
+            }
+        });
+        tags.push((short_name.to_string(), message));
     }
 
     tags.sort_by(|left, right| left.0.cmp(&right.0));
     for (tag, message) in &tags {
         if quiet {
             println!("{tag}");
-        } else {
+        } else if let Some(message) = message {
             println!("{}", format_snapshot_list_line(tag, message));
+        } else {
+            println!("{tag}");
         }
     }
     println!("\n{} snapshot(s)", tags.len());

--- a/crates/agt/tests/integration_tests.rs
+++ b/crates/agt/tests/integration_tests.rs
@@ -755,6 +755,66 @@ fn test_snapshot_list_quiet_shows_only_tags() -> Result<(), Box<dyn std::error::
 
 #[cfg(unix)]
 #[test]
+fn test_snapshot_list_handles_lightweight_tags() -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_list_handles_lightweight_tags");
+    let repo = setup_basic_repo()?;
+    write_agt_config(repo.worktree(), "agt@local", "agtsessions/")?;
+    fs::write(repo.worktree().join("file.txt"), "v1")?;
+
+    let save = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", "annotated snapshot"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(save.status.success());
+    let annotated_tag = parse_snapshot_tag(&String::from_utf8(save.stdout)?);
+    let snapshot_store = repo.worktree().join(".agt-snapshots");
+    let target = Command::new("git")
+        .args([
+            "-C",
+            &snapshot_store.display().to_string(),
+            "rev-parse",
+            "refs/heads/agt-snapshots",
+        ])
+        .output()?;
+    assert!(target.status.success());
+    let target = String::from_utf8(target.stdout)?.trim().to_string();
+
+    let lightweight = Command::new("git")
+        .args([
+            "-C",
+            &snapshot_store.display().to_string(),
+            "tag",
+            "lightweight-only",
+            &target,
+        ])
+        .status()?;
+    assert!(lightweight.success());
+
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "list"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(
+        stdout.contains(&format!("{annotated_tag} annotated snapshot")),
+        "expected annotated tag output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("lightweight-only"),
+        "expected lightweight tag output, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("lightweight-only "),
+        "lightweight tag should not have a forced trailing message column, got: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
 fn test_snapshot_check_reports_changes_between_snapshots() -> Result<(), Box<dyn std::error::Error>>
 {
     log_test_start("test_snapshot_check_reports_changes_between_snapshots");

--- a/crates/agt/tests/integration_tests.rs
+++ b/crates/agt/tests/integration_tests.rs
@@ -641,17 +641,59 @@ fn test_snapshot_list_shows_snapshots() -> Result<(), Box<dyn std::error::Error>
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout)?;
 
+    let second_message = "second snapshot";
+    let first_line = stdout
+        .lines()
+        .find(|line| line.starts_with(&first_tag))
+        .expect("expected first snapshot line in list output");
     assert!(
-        stdout.contains(&first_tag),
-        "expected first tag in list output, got: {stdout}"
+        first_line.starts_with(&format!("{first_tag} snapshot save for ")),
+        "expected default message prefix in list output, got: {stdout}"
     );
     assert!(
-        stdout.contains(&second_tag),
-        "expected second tag in list output, got: {stdout}"
+        stdout.contains(&format!("{second_tag} {second_message}")),
+        "expected second tag and message in list output, got: {stdout}"
     );
     assert!(
         stdout.contains("2 snapshot(s)"),
         "expected count in list output, got: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_snapshot_list_truncates_to_terminal_width() -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_list_truncates_to_terminal_width");
+    let repo = setup_basic_repo()?;
+    write_agt_config(repo.worktree(), "agt@local", "agtsessions/")?;
+    fs::write(repo.worktree().join("file.txt"), "v1")?;
+
+    let message = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-long-message";
+    let save = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", message])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(save.status.success());
+    let tag = parse_snapshot_tag(&String::from_utf8(save.stdout)?);
+
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "list"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    let line = stdout
+        .lines()
+        .find(|line| line.starts_with(&tag))
+        .expect("expected snapshot line in list output");
+
+    assert_eq!(line.len(), 80, "expected 80-char line, got: {line}");
+    assert!(line.starts_with(&format!("{tag} ")));
+    assert!(
+        line.ends_with(".."),
+        "expected truncated suffix, got: {line}"
     );
 
     Ok(())

--- a/crates/agt/tests/integration_tests.rs
+++ b/crates/agt/tests/integration_tests.rs
@@ -701,6 +701,60 @@ fn test_snapshot_list_truncates_to_terminal_width() -> Result<(), Box<dyn std::e
 
 #[cfg(unix)]
 #[test]
+fn test_snapshot_list_quiet_shows_only_tags() -> Result<(), Box<dyn std::error::Error>> {
+    log_test_start("test_snapshot_list_quiet_shows_only_tags");
+    let repo = setup_basic_repo()?;
+    write_agt_config(repo.worktree(), "agt@local", "agtsessions/")?;
+    fs::write(repo.worktree().join("file.txt"), "v1")?;
+
+    let first = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", "first snapshot"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(first.status.success());
+    let first_tag = parse_snapshot_tag(&String::from_utf8(first.stdout)?);
+
+    fs::write(repo.worktree().join("file.txt"), "v2")?;
+    let second = agt_cmd_with_git()?
+        .args(["snapshot", "save", "-m", "second snapshot"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(second.status.success());
+    let second_tag = parse_snapshot_tag(&String::from_utf8(second.stdout)?);
+
+    let output = agt_cmd_with_git()?
+        .args(["snapshot", "list", "-q"])
+        .current_dir(repo.worktree())
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(
+        stdout.contains(&format!("{first_tag}\n")),
+        "expected first tag in quiet output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("{second_tag}\n")),
+        "expected second tag in quiet output, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("first snapshot"),
+        "quiet output should omit messages, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("second snapshot"),
+        "quiet output should omit messages, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("2 snapshot(s)"),
+        "expected count in quiet output, got: {stdout}"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
 fn test_snapshot_check_reports_changes_between_snapshots() -> Result<(), Box<dyn std::error::Error>>
 {
     log_test_start("test_snapshot_check_reports_changes_between_snapshots");

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -290,7 +290,7 @@ COMMANDS
               Options:
                   --store <path>         Snapshot store directory
 
-       agt snapshot list [--store <path>]
+       agt snapshot list [-q] [--store <path>]
               List saved standalone snapshots.
 
               This command prints one snapshot per line as:
@@ -305,7 +305,12 @@ COMMANDS
               would exceed 80 columns, agt truncates it to fit within 80 columns
               by shortening the message and ending the line with `..`.
 
+              • -q
+                     Print only snapshot tags and omit messages. The snapshot
+                     count footer is still shown.
+
               Options:
+                  -q, --quiet           Print only snapshot tags
                   --store <path>         Snapshot store directory
 
        agt snapshot status [-q] [-q] [--store <path>]

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -290,6 +290,24 @@ COMMANDS
               Options:
                   --store <path>         Snapshot store directory
 
+       agt snapshot list [--store <path>]
+              List saved standalone snapshots.
+
+              This command prints one snapshot per line as:
+
+              • <tag> <message>
+
+              The tag is shown in full. The message is the annotated tag message
+              saved by `agt snapshot save -m`, or the default generated message
+              when `-m` was omitted.
+
+              Output is formatted for an 80-column terminal. If the full line
+              would exceed 80 columns, agt truncates it to fit within 80 columns
+              by shortening the message and ending the line with `..`.
+
+              Options:
+                  --store <path>         Snapshot store directory
+
        agt snapshot status [-q] [-q] [--store <path>]
               Compare the current filesystem state against the latest standalone
               snapshot in the store.
@@ -516,6 +534,9 @@ EXAMPLES
 
         Save a standalone snapshot of the current tree:
                $ agt snapshot save -m "before agent run"
+
+        List standalone snapshots with their messages:
+               $ agt snapshot list
 
         Compare two standalone snapshots:
                $ agt snapshot diff 01739800000000000000 01739800001234567890

--- a/docs/agt.1.txt
+++ b/docs/agt.1.txt
@@ -650,4 +650,4 @@ BUGS
 AUTHOR
        Written for AI agent session management and immutable filesystem workflows.
 
-AGT 0.2.1                         January 2026                          AGT(1)
+AGT 0.2.2                         January 2026                          AGT(1)


### PR DESCRIPTION
## Summary
- show snapshot messages in `agt snapshot list`
- truncate snapshot list lines to fit 80-column terminals
- fix `make docs` to render existing `DESIGN_*.md` files
- bump version to 0.2.2

## Testing
- make check
- make docs
- cargo check --workspace
- cargo test -p agt
